### PR TITLE
Upgraded cats library (and other dependencies)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :profiles {:scala2.10 {:dependencies [[org.scala-lang/scala-library "2.10.4"]]}
-             :dev {:dependencies [[org.clojure/clojure "1.6.0"]
+             :dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [org.scala-lang/scala-library "2.11.6"]
                                   [midje "1.6.3"]]
                    :plugins [[lein-midje-doc "0.0.24"]
@@ -17,8 +17,8 @@
                            :sub-title "A Scala interop library for Clojure"
                            :author "Tobias Kortkamp"
                            :email  "tobias.kortkamp@gmail.com"}}}
-  :dependencies [[cats "0.3.2"
+  :dependencies [[funcool/cats "1.2.1"
                   :exclusions [com.keminglabs/cljx
                                org.clojure/clojurescript]]
-                 [potemkin "0.3.12"]]
+                 [potemkin "0.4.3"]]
   :aliases {"test-all" ["do" "midje," "with-profile" "+scala2.10" "midje"]})

--- a/src/t6/from_scala/internal.clj
+++ b/src/t6/from_scala/internal.clj
@@ -4,7 +4,7 @@
             [clojure.string :as str]
             [cats.core :refer (mlet)]
             [cats.protocols :as protocols]
-            [cats.monad.either :refer (left right from-either)])
+            [cats.monad.either :refer (left right)])
   (:import (scala.reflect NameTransformer$)
            (clojure.lang Reflector)))
 
@@ -314,7 +314,7 @@
     (prn &env))
   (let [;; This will try each expression in order and return the first `left` value.
         ;; `failure` throws an exception otherwise, leave it in the last position
-         m (from-either
+         m (deref
              (mlet [m (right {:expr expr
                               :meta (meta expr)
                               :args args})


### PR DESCRIPTION
The version of cats used is not compatible with newer versions of cats (which is causing some issues with codebases that try to use both). Cats, potemkin, and clojure versions have been bumped and adjustments made where comparability was broken.